### PR TITLE
#1557 Resize Split Button to fill its container

### DIFF
--- a/packages/bappo-components/src/components/SplitButton/StyledComponents.native.ts
+++ b/packages/bappo-components/src/components/SplitButton/StyledComponents.native.ts
@@ -6,6 +6,7 @@ import Button from '../Button';
 export const MainButton = styled(Button)`
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+  flex: 1;
 `;
 
 export const MenuButton = styled(Button)`

--- a/packages/bappo-components/src/components/SplitButton/StyledComponents.web.ts
+++ b/packages/bappo-components/src/components/SplitButton/StyledComponents.web.ts
@@ -5,6 +5,7 @@ import Button from '../Button';
 export const MainButton = styled(Button)`
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+  flex: 1;
 `;
 
 export const MenuButton = styled(Button)`


### PR DESCRIPTION
- Changed the Split Button so that the main button will fill the remaining space of the container